### PR TITLE
Get headers value correctly in a edge runtime

### DIFF
--- a/pages/api/requestFromTurku.ts
+++ b/pages/api/requestFromTurku.ts
@@ -5,7 +5,6 @@ export const config = {
 };
 
 export default function handler(req: NextRequest) {
-  console.log(req.headers.get('x-vercel-ip-city'));
   const city = req.headers.get('x-vercel-ip-city') ?? null;
 
   if (city === 'Turku') {


### PR DESCRIPTION
Next.js API routes that run in the Vercel edge function a bit differently than normal API routes
The previous implementation was copied from a edge getServerSideProps call that works almost but not quite like the edge api route thus the headers getting was broken.

This pull request
- changes request type to be edge runtime specific
- gets headers value correctly in edge runtime