### PR TITLE
Use and update translation for heading text

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import BackgroundImage from "components/BackgroundImage";
 import Footer from "components/Footer";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { useTranslation } from "next-i18next";
+import { useTranslation, Trans } from "next-i18next";
 import LanguageSelector from "components/LanguageSelector";
 
 const Home = () => {
@@ -40,7 +40,7 @@ const Home = () => {
       <main className="flex flex-1 flex-col items-center justify-center px-20 text-center space-y-8 text-neutral-100">
         <div>
           <h1 className="text-6xl font-bold">
-            <span className="text-orange-500">Titeenit</span> Turussa
+            <Trans i18nKey="heading" components={{ 1: <span className="text-orange-500" /> }} />
           </h1>
           <p className="text-xl font-bold text-neutral-100">17.-19.3.2023</p>
         </div>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,7 +1,7 @@
 {
     "title": "Turkus Titeenit 2023",
     "description": "Turkus Titeenit 2023 - main event of the year for computer engineering students",
-    "heading": "Titeenit in Turku",
+    "heading": "<1>Titeenit</1> in Turku",
     "in-turku-button": "Am I in Turku?",
     "yes-you-are": "Yes sir 😎",
     "not-yet": "Not yet 🚌",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -1,7 +1,7 @@
 {
     "title": "Turun Titeenit 2023",
     "description": "Turun Titeenit 2023 - vuoden päätapahtuma tietotekniikan opiskelijoille",
-    "heading": "Titeenit Turussa",
+    "heading": "<1>Titeenit</1> Turussa",
     "in-turku-button": "Olenko Turussa?",
     "yes-you-are": "Kyl maar 😎",
     "not-yet": "Et viel 🚌",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -1,7 +1,7 @@
 {
     "title": "Åbos Titeenit 2023",
     "description": "Åbos Titeenit 2023 - årets huvudevenemang för datateknik studenter",
-    "heading": "Titeenit i Åbo",
+    "heading": "<1>Titeenit</1> i Åbo",
     "in-turku-button": "Är jag i Åbo?",
     "yes-you-are": "Åh ja 😎",
     "not-yet": "Inte än 🚌",


### PR DESCRIPTION
The previous translation for the heading wasn't used at all and the Finnish hard coded text was shown for all users. Updates it so that the heading changes based on the language but keeps the different styling for the text "Titeenit"